### PR TITLE
Improve apply performance w/ some experiments

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -58,6 +58,7 @@
 ]}.
 
 {plugins, [
+    % {rebar3_bench, "0.2.1"},
     {erlfmt, "0.8.0"}
 ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -50,7 +50,11 @@
         race_conditions,
         unknown
     ]},
-    {plt_apps, all_deps}
+    {plt_apps, all_deps},
+    {plt_extra_apps, [
+        syntax_tools,
+        compiler
+    ]}
 ]}.
 
 {pre_hooks, [

--- a/src/dmt_domain.erl
+++ b/src/dmt_domain.erl
@@ -383,10 +383,13 @@ references(Object, {set, FieldType}, Refs) ->
     ListObject = ordsets:to_list(Object),
     check_reference_type(ListObject, {list, FieldType}, Refs);
 references(Object, {map, KeyType, ValueType}, Refs) ->
-    check_reference_type(
-        maps:values(Object),
-        {list, ValueType},
-        check_reference_type(maps:keys(Object), {list, KeyType}, Refs)
+    maps:fold(
+        fun(K, V, Acc) ->
+            check_reference_type(V, ValueType,
+                check_reference_type(K, KeyType, Acc))
+        end,
+        Refs,
+        Object
     );
 references(_DomainObject, _Primitive, Refs) ->
     Refs.

--- a/src/dmt_domain.erl
+++ b/src/dmt_domain.erl
@@ -2,6 +2,8 @@
 
 -include_lib("damsel/include/dmsl_domain_config_thrift.hrl").
 
+-compile({parse_transform, dmt_domain_pt}).
+
 %%
 
 -export([new/0]).
@@ -153,10 +155,9 @@ integrity_check(Domain, Touched) when is_list(Touched) ->
     % TODO
     % Well I guess nothing (but the types) stops us from accumulating
     % errors from every check, instead of just first failed
-    Mapping = mk_reference_type_mapping(),
     run_until_error([
-        fun() -> verify_integrity(Domain, Touched, Mapping) end,
-        fun() -> verify_acyclicity(Domain, Touched, {[], #{}}, Mapping) end
+        fun() -> verify_integrity(Domain, Touched) end,
+        fun() -> verify_acyclicity(Domain, Touched, {[], #{}}) end
     ]).
 
 run_until_error([CheckFun | Rest]) ->
@@ -169,9 +170,9 @@ run_until_error([CheckFun | Rest]) ->
 run_until_error([]) ->
     ok.
 
-verify_integrity(Domain, Touched, Mapping) ->
-    ObjectsNotExist1 = verify_forward_integrity(Domain, Touched, [], Mapping),
-    ObjectsNotExist2 = verify_backward_integrity(Domain, Touched, ObjectsNotExist1, Mapping),
+verify_integrity(Domain, Touched) ->
+    ObjectsNotExist1 = verify_forward_integrity(Domain, Touched, []),
+    ObjectsNotExist2 = verify_backward_integrity(Domain, Touched, ObjectsNotExist1),
     case ObjectsNotExist2 of
         [] ->
             ok;
@@ -179,11 +180,11 @@ verify_integrity(Domain, Touched, Mapping) ->
             {error, {objects_not_exist, ObjectsNotExist2}}
     end.
 
-verify_forward_integrity(Domain, Ops, ObjectsNotExistAcc, Mapping) ->
+verify_forward_integrity(Domain, Ops, ObjectsNotExistAcc) ->
     lists:foldl(
         fun
             ({Op, Object}, Acc) when Op == insert; Op == update ->
-                Acc ++ check_correct_refs(Object, Domain, Mapping);
+                Acc ++ check_correct_refs(Object, Domain);
             (_, Acc) ->
                 Acc
         end,
@@ -191,26 +192,26 @@ verify_forward_integrity(Domain, Ops, ObjectsNotExistAcc, Mapping) ->
         Ops
     ).
 
-verify_backward_integrity(Domain, Ops, ObjectsNotExistAcc, Mapping) ->
+verify_backward_integrity(Domain, Ops, ObjectsNotExistAcc) ->
     RemovedRefs = [get_ref(Object) || {remove, Object} <- Ops],
-    ObjectsNotExistAcc ++ check_no_refs(RemovedRefs, Domain, Mapping).
+    ObjectsNotExistAcc ++ check_no_refs(RemovedRefs, Domain).
 
-verify_acyclicity(_Domain, [], {[], _}, _) ->
+verify_acyclicity(_Domain, [], {[], _}) ->
     ok;
-verify_acyclicity(_Domain, [], {Cycles, _}, _) ->
+verify_acyclicity(_Domain, [], {Cycles, _}) ->
     {error, {object_reference_cycles, Cycles}};
-verify_acyclicity(Domain, [{Op, Object} | Rest], Acc, Mapping) when Op == insert; Op == update ->
-    Acc1 = track_cycles_from(get_ref(Object), Object, Acc, Domain, Mapping),
-    verify_acyclicity(Domain, Rest, Acc1, Mapping);
-verify_acyclicity(Domain, [{remove, _} | Rest], Acc, Mapping) ->
-    verify_acyclicity(Domain, Rest, Acc, Mapping).
+verify_acyclicity(Domain, [{Op, Object} | Rest], Acc) when Op == insert; Op == update ->
+    Acc1 = track_cycles_from(get_ref(Object), Object, Acc, Domain),
+    verify_acyclicity(Domain, Rest, Acc1);
+verify_acyclicity(Domain, [{remove, _} | Rest], Acc) ->
+    verify_acyclicity(Domain, Rest, Acc).
 
-check_correct_refs(DomainObject, Domain, Mapping) ->
+check_correct_refs(DomainObject, Domain) ->
     NonExistent = lists:filter(
         fun(E) ->
             not object_exists(E, Domain)
         end,
-        references(DomainObject, Mapping)
+        references(DomainObject)
     ),
     Ref = get_ref(DomainObject),
     lists:map(fun(X) -> {X, [Ref]} end, NonExistent).
@@ -223,15 +224,15 @@ object_exists(Ref, Domain) ->
             false
     end.
 
-check_no_refs(Refs, Domain, Mapping) ->
-    case maps:to_list(referenced_by(Refs, Domain, Mapping)) of
+check_no_refs(Refs, Domain) ->
+    case maps:to_list(referenced_by(Refs, Domain)) of
         [] ->
             [];
         ReferencedBy ->
             ReferencedBy
     end.
 
-track_cycles_from(Ref, Object, {Acc, Blocklist}, Domain, Mapping) ->
+track_cycles_from(Ref, Object, {Acc, Blocklist}, Domain) ->
     %% NOTE
     %%
     %% This is an implementation of [Johnson's algorithm for enumerating
@@ -257,14 +258,14 @@ track_cycles_from(Ref, Object, {Acc, Blocklist}, Domain, Mapping) ->
     %% graph, and no operation introducing a cycle could succeed.
     %%
     %% [1]: https://www.cs.tufts.edu/comp/150GA/homeworks/hw1/Johnson%2075.PDF
-    {_Found, Acc1, _Blocklist} = track_cycles_over(Object, Ref, [Ref], Acc, Blocklist, Domain, Mapping),
+    {_Found, Acc1, _Blocklist} = track_cycles_over(Object, Ref, [Ref], Acc, Blocklist, Domain),
     {Acc1, block_node(Ref, Blocklist)}.
 
-track_cycles_over(DomainObject, Pivot, [Ref | _] = PathRev, Acc, Blocklist, Domain, Mapping) ->
+track_cycles_over(DomainObject, Pivot, [Ref | _] = PathRev, Acc, Blocklist, Domain) ->
     %% NOTE
     %% Returns _all_ cycles passing through the node `Pivot`.
     %% This is essentially CIRCUIT(v) routine from the [paper][1].
-    Refs = references(DomainObject, Mapping),
+    Refs = references(DomainObject),
     %% We begin by blocking current node so that any search passing through
     %% this node (but not through `Pivot`) would terminate prematurely.
     Blocklist1 = block_node(Ref, Blocklist),
@@ -273,7 +274,7 @@ track_cycles_over(DomainObject, Pivot, [Ref | _] = PathRev, Acc, Blocklist, Doma
             %% We iterate over adjacent nodes here, accumulating cycles and
             %% blocklist. If _any_ cycle is found in any subgraph then `Found`
             %% will become `true`.
-            track_edge(NextRef, Pivot, PathRev, FAcc, CAcc, BLAcc, Domain, Mapping)
+            track_edge(NextRef, Pivot, PathRev, FAcc, CAcc, BLAcc, Domain)
         end,
         {false, Acc, Blocklist1},
         Refs
@@ -290,12 +291,12 @@ track_cycles_over(DomainObject, Pivot, [Ref | _] = PathRev, Acc, Blocklist, Doma
         end,
     {Found, Acc1, Blocklist3}.
 
-track_edge(Ref, Ref, PathRev, _Found, Acc, Blocklist, _Domain, _Mapping) ->
+track_edge(Ref, Ref, PathRev, _Found, Acc, Blocklist, _Domain) ->
     % We found a cycle passing through `Pivot`.
     % That means we must return with `true` to a caller.
     Acc1 = [lists:reverse(PathRev) | Acc],
     {true, Acc1, Blocklist};
-track_edge(Ref, Pivot, PathRev, Found, Acc, Blocklist, Domain, Mapping) ->
+track_edge(Ref, Pivot, PathRev, Found, Acc, Blocklist, Domain) ->
     case is_blocked(Ref, Blocklist) of
         true ->
             % Node is blocked.
@@ -307,7 +308,7 @@ track_edge(Ref, Pivot, PathRev, Found, Acc, Blocklist, Domain, Mapping) ->
             % First time here.
             case get_object(Ref, Domain) of
                 {ok, Object} ->
-                    track_cycles_over(Object, Pivot, [Ref | PathRev], Acc, Blocklist, Domain, Mapping);
+                    track_cycles_over(Object, Pivot, [Ref | PathRev], Acc, Blocklist, Domain);
                 error ->
                     {Found, Acc, Blocklist}
             end
@@ -322,11 +323,11 @@ is_blocked(Ref, Blocklist) ->
 unblock_node(Ref, Blocklist) ->
     maps:remove(Ref, Blocklist).
 
-referenced_by(Refs, Domain, Mapping) ->
+referenced_by(Refs, Domain) ->
     RefSet = ordsets:from_list(Refs),
     maps:fold(
         fun(K, V, Acc0) ->
-            OutRefSet = ordsets:from_list(references(V, Mapping)),
+            OutRefSet = ordsets:from_list(references(V)),
             Intersection = ordsets:intersection(RefSet, OutRefSet),
             ordsets:fold(
                 fun(Ref, Acc) -> map_append(Ref, K, Acc) end,
@@ -341,23 +342,23 @@ referenced_by(Refs, Domain, Mapping) ->
 map_append(K, V, M) ->
     maps:put(K, [V | maps:get(K, M, [])], M).
 
-references(DomainObject, Mapping) ->
+references(DomainObject) ->
     {DataType, Data} = get_data(DomainObject),
-    references(Data, DataType, Mapping).
+    references(Data, DataType).
 
-references(Object, DataType, Mapping) ->
-    references(Object, DataType, [], Mapping).
+references(Object, DataType) ->
+    references(Object, DataType, []).
 
-references(undefined, _StructInfo, Refs, _) ->
+references(undefined, _StructInfo, Refs) ->
     Refs;
-references({Tag, Object}, StructInfo = {struct, union, FieldsInfo}, Refs, Mapping) when is_list(FieldsInfo) ->
+references({Tag, Object}, StructInfo = {struct, union, FieldsInfo}, Refs) when is_list(FieldsInfo) ->
     case get_field_info(Tag, StructInfo) of
         false ->
             erlang:error({<<"field info not found">>, Tag, StructInfo});
         {_, _, Type, _, _} ->
-            check_reference_type(Object, Type, Refs, Mapping)
+            check_reference_type(Object, Type, Refs)
     end;
-references(Object, {struct, struct, FieldsInfo}, Refs, Mapping) when is_list(FieldsInfo) -> %% what if it's a union?
+references(Object, {struct, struct, FieldsInfo}, Refs) when is_list(FieldsInfo) -> %% what if it's a union?
     indexfold(
         fun
             (I, {_, _Required, FieldType, _Name, _}, Acc) ->
@@ -365,7 +366,7 @@ references(Object, {struct, struct, FieldsInfo}, Refs, Mapping) when is_list(Fie
                     undefined ->
                         Acc;
                     Field ->
-                        check_reference_type(Field, FieldType, Acc, Mapping)
+                        check_reference_type(Field, FieldType, Acc)
                 end
         end,
         Refs,
@@ -374,30 +375,30 @@ references(Object, {struct, struct, FieldsInfo}, Refs, Mapping) when is_list(Fie
         2,
         FieldsInfo
     );
-references(Object, {struct, _, {?DOMAIN, StructName}}, Refs, Mapping) ->
+references(Object, {struct, _, {?DOMAIN, StructName}}, Refs) ->
     StructInfo = get_struct_info(StructName),
-    check_reference_type(Object, StructInfo, Refs, Mapping);
-references(Object, {list, FieldType}, Refs, Mapping) ->
+    check_reference_type(Object, StructInfo, Refs);
+references(Object, {list, FieldType}, Refs) ->
     lists:foldl(
         fun(O, Acc) ->
-            check_reference_type(O, FieldType, Acc, Mapping)
+            check_reference_type(O, FieldType, Acc)
         end,
         Refs,
         Object
     );
-references(Object, {set, FieldType}, Refs, Mapping) ->
+references(Object, {set, FieldType}, Refs) ->
     ListObject = ordsets:to_list(Object),
-    check_reference_type(ListObject, {list, FieldType}, Refs, Mapping);
-references(Object, {map, KeyType, ValueType}, Refs, Mapping) ->
+    check_reference_type(ListObject, {list, FieldType}, Refs);
+references(Object, {map, KeyType, ValueType}, Refs) ->
     maps:fold(
         fun(K, V, Acc) ->
             check_reference_type(V, ValueType,
-                check_reference_type(K, KeyType, Acc, Mapping), Mapping)
+                check_reference_type(K, KeyType, Acc))
         end,
         Refs,
         Object
     );
-references(_DomainObject, _Primitive, Refs, _) ->
+references(_DomainObject, _Primitive, Refs) ->
     Refs.
 
 indexfold(Fun, Acc, I, [E | Rest]) ->
@@ -405,12 +406,12 @@ indexfold(Fun, Acc, I, [E | Rest]) ->
 indexfold(_Fun, Acc, _I, []) ->
     Acc.
 
-check_reference_type(Object, Type, Refs, Mapping) ->
-    case is_reference_type(Type, Mapping) of
+check_reference_type(Object, Type, Refs) ->
+    case is_reference_type(Type) of
         {true, Tag} ->
             [{Tag, Object} | Refs];
         false ->
-            references(Object, Type, Refs, Mapping)
+            references(Object, Type, Refs)
     end.
 
 -spec get_ref(domain_object()) -> object_ref().
@@ -456,12 +457,16 @@ get_field_index(Field, I, [F | Rest]) ->
             get_field_index(Field, I + 1, Rest)
     end.
 
-is_reference_type(Type, Mapping) ->
-    maps:get(Type, Mapping, false).
-
-mk_reference_type_mapping() ->
+is_reference_type(Type) ->
     {struct, union, StructInfo} = get_struct_info('Reference'),
-    maps:from_list([{Tp, {true, Tag}} || {_, _, Tp, Tag, _} <- StructInfo]).
+    is_reference_type(Type, StructInfo).
+
+is_reference_type(_Type, []) ->
+    false;
+is_reference_type(Type, [{_, _, Type, Tag, _} | _Rest]) ->
+    {true, Tag};
+is_reference_type(Type, [_ | Rest]) ->
+    is_reference_type(Type, Rest).
 
 invert_operation({insert, #'InsertOp'{object = Object}}) ->
     {remove, #'RemoveOp'{object = Object}};

--- a/src/dmt_domain.erl
+++ b/src/dmt_domain.erl
@@ -360,7 +360,12 @@ references(Object, {struct, struct, FieldsInfo}, Refs) when is_list(FieldsInfo) 
     indexfold(
         fun
             (I, {_, _Required, FieldType, _Name, _}, Acc) ->
-                check_reference_type(element(I, Object), FieldType, Acc)
+                case element(I, Object) of
+                    undefined ->
+                        Acc;
+                    Field ->
+                        check_reference_type(Field, FieldType, Acc)
+                end
         end,
         Refs,
         % NOTE
@@ -399,8 +404,6 @@ indexfold(Fun, Acc, I, [E | Rest]) ->
 indexfold(_Fun, Acc, _I, []) ->
     Acc.
 
-check_reference_type(undefined, _, Refs) ->
-    Refs;
 check_reference_type(Object, Type, Refs) ->
     case is_reference_type(Type) of
         {true, Tag} ->

--- a/src/dmt_domain.erl
+++ b/src/dmt_domain.erl
@@ -358,16 +358,16 @@ references({Tag, Object}, StructInfo = {struct, union, FieldsInfo}, Refs) when i
         {_, _, Type, _, _} ->
             check_reference_type(Object, Type, Refs)
     end;
-references(Object, {struct, struct, FieldsInfo}, Refs) when is_list(FieldsInfo) -> %% what if it's a union?
+%% what if it's a union?
+references(Object, {struct, struct, FieldsInfo}, Refs) when is_list(FieldsInfo) ->
     indexfold(
-        fun
-            (I, {_, _Required, FieldType, _Name, _}, Acc) ->
-                case element(I, Object) of
-                    undefined ->
-                        Acc;
-                    Field ->
-                        check_reference_type(Field, FieldType, Acc)
-                end
+        fun(I, {_, _Required, FieldType, _Name, _}, Acc) ->
+            case element(I, Object) of
+                undefined ->
+                    Acc;
+                Field ->
+                    check_reference_type(Field, FieldType, Acc)
+            end
         end,
         Refs,
         % NOTE
@@ -392,8 +392,11 @@ references(Object, {set, FieldType}, Refs) ->
 references(Object, {map, KeyType, ValueType}, Refs) ->
     maps:fold(
         fun(K, V, Acc) ->
-            check_reference_type(V, ValueType,
-                check_reference_type(K, KeyType, Acc))
+            check_reference_type(
+                V,
+                ValueType,
+                check_reference_type(K, KeyType, Acc)
+            )
         end,
         Refs,
         Object
@@ -448,7 +451,6 @@ get_field_index(Field, {struct, _StructType, FieldsInfo}) ->
 
 get_field_index(_Field, _, []) ->
     false;
-
 get_field_index(Field, I, [F | Rest]) ->
     case F of
         {_, _, _, Field, _} = Info ->

--- a/src/dmt_domain_pt.erl
+++ b/src/dmt_domain_pt.erl
@@ -6,10 +6,10 @@
     Forms :: [erl_parse:abstract_form() | erl_parse:form_info()].
 parse_transform(Forms, _Options) ->
     [
-        erl_syntax:revert(FormNext) ||
-            Form <- Forms,
-                FormNext <- [erl_syntax_lib:map(fun transform/1, Form)],
-                    FormNext /= delete
+        erl_syntax:revert(FormNext)
+        || Form <- Forms,
+           FormNext <- [erl_syntax_lib:map(fun transform/1, Form)],
+           FormNext /= delete
     ].
 
 transform(Form) ->
@@ -32,21 +32,24 @@ transform_function(Name = is_reference_type, 1, FormWas) ->
     % is_reference_type(_) -> false.
     % ```
     {struct, union, StructInfo} = get_struct_info('Reference'),
-    Clauses = [
-        erl_syntax:clause(
-            [erl_syntax:abstract(Type)],
-            none,
-            [erl_syntax:abstract({true, Tag})]
-        ) || {_N, _Req, Type, Tag, _Default} <- StructInfo
-    ] ++ [
-        erl_syntax:clause(
-            [erl_syntax:underscore()],
-            none,
-            [erl_syntax:abstract(false)]
-        )
-    ],
+    Clauses =
+        [
+            erl_syntax:clause(
+                [erl_syntax:abstract(Type)],
+                none,
+                [erl_syntax:abstract({true, Tag})]
+            )
+            || {_N, _Req, Type, Tag, _Default} <- StructInfo
+        ] ++
+            [
+                erl_syntax:clause(
+                    [erl_syntax:underscore()],
+                    none,
+                    [erl_syntax:abstract(false)]
+                )
+            ],
     Form = erl_syntax_lib:map(
-        fun (F) -> erl_syntax:copy_attrs(FormWas, F) end,
+        fun(F) -> erl_syntax:copy_attrs(FormWas, F) end,
         erl_syntax:function(
             erl_syntax:abstract(Name),
             Clauses

--- a/src/dmt_domain_pt.erl
+++ b/src/dmt_domain_pt.erl
@@ -1,0 +1,65 @@
+-module(dmt_domain_pt).
+
+-export([parse_transform/2]).
+
+-spec parse_transform(Forms, [compile:option()]) -> Forms when
+    Forms :: [erl_parse:abstract_form() | erl_parse:form_info()].
+parse_transform(Forms, _Options) ->
+    [
+        erl_syntax:revert(FormNext) ||
+            Form <- Forms,
+                FormNext <- [erl_syntax_lib:map(fun transform/1, Form)],
+                    FormNext /= delete
+    ].
+
+transform(Form) ->
+    case erl_syntax:type(Form) of
+        function ->
+            Name = erl_syntax:concrete(erl_syntax:function_name(Form)),
+            Arity = erl_syntax:function_arity(Form),
+            transform_function(Name, Arity, Form);
+        _ ->
+            Form
+    end.
+
+transform_function(Name = is_reference_type, 1, FormWas) ->
+    % NOTE
+    % Replacing `dmt_domain:is_reference_type/1` with a code which does something similar to:
+    % ```
+    % is_reference_type({struct, struct, {dmsl_domain_thrift, 'CategoryRef'}}) -> {true, 'category'};
+    % is_reference_type({struct, struct, {dmsl_domain_thrift, 'CurrencyRef'}}) -> {true, 'currency'};
+    % ...
+    % is_reference_type(_) -> false.
+    % ```
+    {struct, union, StructInfo} = get_struct_info('Reference'),
+    Clauses = [
+        erl_syntax:clause(
+            [erl_syntax:abstract(Type)],
+            none,
+            [erl_syntax:abstract({true, Tag})]
+        ) || {_N, _Req, Type, Tag, _Default} <- StructInfo
+    ] ++ [
+        erl_syntax:clause(
+            [erl_syntax:underscore()],
+            none,
+            [erl_syntax:abstract(false)]
+        )
+    ],
+    Form = erl_syntax_lib:map(
+        fun (F) -> erl_syntax:copy_attrs(FormWas, F) end,
+        erl_syntax:function(
+            erl_syntax:abstract(Name),
+            Clauses
+        )
+    ),
+    Form;
+transform_function(_Name = is_reference_type, 2, _FormWas) ->
+    % NOTE
+    % We need to make `is_reference_type/2` disappear, otherwise it will trigger _unused function_
+    % warning.
+    delete;
+transform_function(_, _, Form) ->
+    Form.
+
+get_struct_info(StructName) ->
+    dmsl_domain_thrift:struct_info(StructName).

--- a/test/bench_apply_operations.erl
+++ b/test/bench_apply_operations.erl
@@ -16,8 +16,7 @@
     history = #{} :: #{_Version => commit()}
 }).
 
--spec repository_state() ->
-    term().
+-spec repository_state() -> term().
 repository_state() ->
     % NOTE
     % There's no such file in the repo, sorry. If you want to employ this benchmarking code you'd
@@ -25,8 +24,7 @@ repository_state() ->
     {ok, Bin} = file:read_file("test/domain-config.history.10.bert"),
     erlang:binary_to_term(Bin).
 
--spec apply_operations({input, _State}) ->
-    term().
+-spec apply_operations({input, _State}) -> term().
 apply_operations({input, _}) ->
     St0 = #st{history = History0} = repository_state(),
     History1 = maps:with(lists:sublist(lists:sort(maps:keys(History0)), 3), History0),
@@ -39,20 +37,23 @@ compute_operation_stats(#st{snapshot = Snapshot, history = History}) ->
     NumUpdates = count_history_operations(update, History),
     NumRemoves = count_history_operations(remove, History),
     _ = io:format(user, "~n", []),
-    [io:format(user, "~24.ts: ~p~n", Args) || Args <- [
-        ["Snapshot version"     , Snapshot#'Snapshot'.version],
-        ["Snapshot size"        , maps:size(Snapshot#'Snapshot'.domain)],
-        ["Number of commits"    , maps:size(History)],
-        ["Number of operations" , NumInserts + NumUpdates + NumRemoves],
-        ["Number of insertions" , NumInserts],
-        ["Number of updates"    , NumUpdates],
-        ["Number of removals"   , NumRemoves]
-    ]],
+    [
+        io:format(user, "~24.ts: ~p~n", Args)
+        || Args <- [
+               ["Snapshot version", Snapshot#'Snapshot'.version],
+               ["Snapshot size", maps:size(Snapshot#'Snapshot'.domain)],
+               ["Number of commits", maps:size(History)],
+               ["Number of operations", NumInserts + NumUpdates + NumRemoves],
+               ["Number of insertions", NumInserts],
+               ["Number of updates", NumUpdates],
+               ["Number of removals", NumRemoves]
+           ]
+    ],
     io:format(user, "~n", []).
 
 count_history_operations(Type, History = #{}) ->
     maps:fold(
-        fun (_, #'Commit'{ops = Ops}, N) ->
+        fun(_, #'Commit'{ops = Ops}, N) ->
             N + count_commit_operations(Type, Ops)
         end,
         0,
@@ -61,7 +62,7 @@ count_history_operations(Type, History = #{}) ->
 
 count_commit_operations(Type, Ops) ->
     lists:foldl(
-        fun ({TypeOp, _Op}, N) ->
+        fun({TypeOp, _Op}, N) ->
             case TypeOp of
                 Type -> N + 1;
                 _ -> N
@@ -71,7 +72,6 @@ count_commit_operations(Type, Ops) ->
         Ops
     ).
 
--spec bench_apply_operations(#st{}, _State) ->
-    term().
+-spec bench_apply_operations(#st{}, _State) -> term().
 bench_apply_operations(#st{snapshot = Snapshot, history = History}, _) ->
     dmt_history:head(History, Snapshot).

--- a/test/bench_apply_operations.erl
+++ b/test/bench_apply_operations.erl
@@ -1,0 +1,77 @@
+-module(bench_apply_operations).
+
+%% API
+-export([
+    apply_operations/1,
+    bench_apply_operations/2
+]).
+
+-include_lib("damsel/include/dmsl_domain_config_thrift.hrl").
+
+-type snapshot() :: dmsl_domain_config_thrift:'Snapshot'().
+-type commit() :: dmsl_domain_config_thrift:'Commit'().
+
+-record(st, {
+    snapshot = #'Snapshot'{version = 0, domain = dmt_domain:new()} :: snapshot(),
+    history = #{} :: #{_Version => commit()}
+}).
+
+-spec repository_state() ->
+    term().
+repository_state() ->
+    % NOTE
+    % There's no such file in the repo, sorry. If you want to employ this benchmarking code you'd
+    % have to synthesize it yourself, luckily there's a typespec.
+    {ok, Bin} = file:read_file("test/domain-config.history.10.bert"),
+    erlang:binary_to_term(Bin).
+
+-spec apply_operations({input, _State}) ->
+    term().
+apply_operations({input, _}) ->
+    St0 = #st{history = History0} = repository_state(),
+    History1 = maps:with(lists:sublist(lists:sort(maps:keys(History0)), 3), History0),
+    St1 = St0#st{history = History1},
+    _ = compute_operation_stats(St1),
+    St1.
+
+compute_operation_stats(#st{snapshot = Snapshot, history = History}) ->
+    NumInserts = count_history_operations(insert, History),
+    NumUpdates = count_history_operations(update, History),
+    NumRemoves = count_history_operations(remove, History),
+    _ = io:format(user, "~n", []),
+    [io:format(user, "~24.ts: ~p~n", Args) || Args <- [
+        ["Snapshot version"     , Snapshot#'Snapshot'.version],
+        ["Snapshot size"        , maps:size(Snapshot#'Snapshot'.domain)],
+        ["Number of commits"    , maps:size(History)],
+        ["Number of operations" , NumInserts + NumUpdates + NumRemoves],
+        ["Number of insertions" , NumInserts],
+        ["Number of updates"    , NumUpdates],
+        ["Number of removals"   , NumRemoves]
+    ]],
+    io:format(user, "~n", []).
+
+count_history_operations(Type, History = #{}) ->
+    maps:fold(
+        fun (_, #'Commit'{ops = Ops}, N) ->
+            N + count_commit_operations(Type, Ops)
+        end,
+        0,
+        History
+    ).
+
+count_commit_operations(Type, Ops) ->
+    lists:foldl(
+        fun ({TypeOp, _Op}, N) ->
+            case TypeOp of
+                Type -> N + 1;
+                _ -> N
+            end
+        end,
+        0,
+        Ops
+    ).
+
+-spec bench_apply_operations(#st{}, _State) ->
+    term().
+bench_apply_operations(#st{snapshot = Snapshot, history = History}, _) ->
+    dmt_history:head(History, Snapshot).


### PR DESCRIPTION
## Workload

Snapshot version: 23490
Snapshot size: 5664
Number of commits: 3
Number of operations: 102
Number of insertions: 0
Number of updates: 0
Number of removals: 102

## Results

Numbers after each iteration. I had to remeasure **2** under laptop battery power setting, that's why numbers afterwards look a bit higher.

### 1. No mark_fields (10fde55)

Compared to **baseline** on master.

```
===> Stats for wall_time
Min:                721.62ms (-   37.81ms /  5.0%)
25 percentile:      727.49ms (-   36.58ms /  4.8%)
Median:             731.06ms (-   38.02ms /  4.9%)
75 percentile:      732.70ms (-   42.69ms /  5.5%)
Max:                769.08ms (-   48.19ms /  5.9%)
Outliers:         Lo: 0; Hi: 1; Sum: 1
Outlier variance: 4.75000e-2 (slight)
> Bootstrapped
Mean:               732.29ms (-   40.91ms /  5.3%)
Std deviation:     9800.67μs
> Relative
Difference at 95.0 confidence
   -40.91ms ±  7686.70μs
    -5.29%  ±  0.99%
 (Student's t, pooled s = 1.20096e+7
```

### 2. Straightforward maps:fold (ef3a987)

Compared to **1** profile.

```
===> Stats for wall_time
Min:                710.96ms (-   11.34ms /  1.6%)
25 percentile:      714.78ms (-   14.62ms /  2.0%)
Median:             731.30ms (- 7843.70μs /  1.1%)
75 percentile:      740.59ms (- 2033.11μs /  0.3%)
Max:                749.82ms (-   38.80ms /  4.9%)
Outliers:         Lo: 0; Hi: 0; Sum: 0
Outlier variance: 4.75000e-2 (slight)
> Bootstrapped
Mean:               729.58ms (-   12.54ms /  1.7%)
Std deviation:       12.13ms
> Relative
Difference at 95.0 confidence
   -12.54ms ±  9383.82μs
    -1.69%  ±  1.26%
 (Student's t, pooled s = 1.46612e+7
```

### 3. Less useless `undefined` matching (1b255a2)

Compared to **2**, measured under _battery_ setting, hence the numbers.

Even though no statistically significant improvement was observed, results were consistent through several runs.

```
===> Stats for wall_time
Min:                710.07ms (- 3943.33μs /  0.6%)
25 percentile:      719.05ms (- 3650.90μs /  0.5%)
Median:             727.46ms (- 1068.10μs /  0.1%)
75 percentile:      740.76ms (- 1397.55μs /  0.2%)
Max:                747.87ms (-   80.81μs /  0.0%)
Outliers:         Lo: 0; Hi: 0; Sum: 0
Outlier variance: 4.75000e-2 (slight)
> Bootstrapped
Mean:               730.28ms (- 1000.93μs /  0.1%)
Std deviation:       11.67ms
> Relative
No difference found at 95.0% confidence level
```

### 4. With precomputed reftype mapping (5176848)

Compared to **2**, measured under _battery_ setting.

```
===> Stats for wall_time
Min:                440.27ms (-  273.74ms / 38.3%)
25 percentile:      446.27ms (-  276.43ms / 38.3%)
Median:             454.35ms (-  274.18ms / 37.6%)
75 percentile:      464.81ms (-  277.34ms / 37.4%)
Max:                471.85ms (-  276.10ms / 36.9%)
Outliers:         Lo: 0; Hi: 0; Sum: 0
Outlier variance: 4.75000e-2 (slight)
> Bootstrapped
Mean:               455.99ms (-  275.29ms / 37.6%)
Std deviation:       11.32ms
> Relative
Difference at 95.0 confidence
  -275.29ms ±  7372.71μs
   -37.65%  ±  1.01%
 (Student's t, pooled s = 1.15190e+7
```

### 5. With parse transform hack (aa957fa)

Compared to **2**, measured under _battery_ setting.

```
===> Stats for wall_time
Min:                120.71ms (-  593.30ms / 83.1%)
25 percentile:      121.59ms (-  601.11ms / 83.2%)
Median:             123.04ms (-  605.49ms / 83.1%)
75 percentile:      123.62ms (-  618.54ms / 83.3%)
Max:                127.29ms (-  620.66ms / 83.0%)
Outliers:         Lo: 0; Hi: 1; Sum: 1
Outlier variance: 4.75000e-2 (slight)
> Bootstrapped
Mean:               122.97ms (-  608.31ms / 83.2%)
Std deviation:     1576.56μs
> Relative
Difference at 95.0 confidence
  -608.31ms ±  5351.30μs
   -83.18%  ±  0.73%
 (Student's t, pooled s = 8.36082e+6
```
